### PR TITLE
Add conversational dependency gathering.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,11 +2,15 @@
   "name": "@drush-io/hubot-drush-io",
   "version": "1.0.0-beta.3",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@drush-io/api-client": {
       "version": "1.0.0-alpha.3",
       "resolved": "https://registry.npmjs.org/@drush-io/api-client/-/api-client-1.0.0-alpha.3.tgz",
-      "integrity": "sha1-rMqDnvB7FN6ZjSwwaIx88th0Opw="
+      "integrity": "sha1-rMqDnvB7FN6ZjSwwaIx88th0Opw=",
+      "requires": {
+        "popsicle": "9.1.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -16,12 +20,20 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -33,6 +45,11 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
       "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
     },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -41,12 +58,29 @@
     "fernet": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/fernet/-/fernet-0.3.0.tgz",
-      "integrity": "sha1-xoJnJUmc3DhgTG3Si7h5sebVVUw="
+      "integrity": "sha1-xoJnJUmc3DhgTG3Si7h5sebVVUw=",
+      "requires": {
+        "crypto-js": "3.1.8",
+        "urlsafe-base64": "0.0.2"
+      }
     },
     "form-data": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.2.0.tgz",
-      "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs="
+      "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
+    },
+    "hubot-conversation": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hubot-conversation/-/hubot-conversation-1.1.1.tgz",
+      "integrity": "sha1-+Ak36pIue+m1XsPoWUZlaKX9p20=",
+      "requires": {
+        "debuglog": "1.0.1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -66,7 +100,10 @@
     "make-error-cause": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
-      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0="
+      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
+      "requires": {
+        "make-error": "1.3.0"
+      }
     },
     "mime-db": {
       "version": "1.27.0",
@@ -76,12 +113,21 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "popsicle": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-9.1.0.tgz",
-      "integrity": "sha1-T5APONV6V07BcO2kBJbjZAgr/2Y="
+      "integrity": "sha1-T5APONV6V07BcO2kBJbjZAgr/2Y=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "form-data": "2.2.0",
+        "make-error-cause": "1.2.2",
+        "tough-cookie": "2.3.2"
+      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -96,7 +142,16 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ=="
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -106,12 +161,18 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@drush-io/api-client": "^1.0.0-alpha.3",
-    "fernet": "^0.3.0"
+    "fernet": "^0.3.0",
+    "hubot-conversation": "^1.1.1"
   }
 }


### PR DESCRIPTION
Removes `drush-io run <job> with <VAR>="<VAR_VALUE>"` syntax in favor of walking a dependency list via `hubot-conversation`.

Closes #2 